### PR TITLE
Update Setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,15 @@
 Powered by Pandoc
 
 ## Setup
+- Install [Node](https://nodejs.org/en/download) for your platform
 - Install [Pandoc](https://pandoc.org/installing.html) for your platform
 - Install [LaTeX](https://www.latex-project.org/get/) for your platform
+
+> ℹ️ For macOS users the fastest way to install the above dependencies is via `homebrew`:
+> ```
+> brew install node pandoc basictex
+> ```
+
 
 ## Edit
 - Open the `source.md` file in your text editor (for example [Visual Studio Code](https://code.visualstudio.com/))
@@ -11,6 +18,7 @@ Powered by Pandoc
 
 ## Build
 - Run `npm run build:epub` to generate **epub**
+OR
 - Run `npm run build:pdf` to generate **pdf**
 OR
 - Run `npm run build` to generate all formats


### PR DESCRIPTION
- The setup requires `npm` to work, so I've added Node to the setup list
- It took me sometime to figure out why `pdflatex` command "not found". The first suggestion on LaTeX page (MacTex) didn't work as expected, so had to go with BasicTex. Hence, adding the suggested command to install all the dependencies at once